### PR TITLE
fix demo-app references to lib

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import {Store} from '@ngrx/store';
-import {AuthActions} from '@xtream/firebase-ngrx-user-management';
+import {AuthActions} from '../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 import {AuthState} from '../../projects/xtream/firebase-ngrx-user-management/src/lib/reducers';
 
 @Component({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,7 +11,7 @@ import {environment} from '../environments/environment';
 import {StoreModule} from '@ngrx/store';
 import {reducers} from './core/reducers';
 import {StoreDevtoolsModule} from '@ngrx/store-devtools';
-import {FirebaseNgrxUserManagementModule} from '@xtream/firebase-ngrx-user-management';
+import {FirebaseNgrxUserManagementModule} from '../../projects/xtream/firebase-ngrx-user-management/src/lib/firebase-ngrx-user-management.module';
 import {EffectsModule} from '@ngrx/effects';
 import {ToolbarContainerComponent} from './toolbar/containers/toolbar-container/toolbar-container.component';
 import {ToolbarComponent} from './toolbar/components/toolbar/toolbar.component';

--- a/src/app/login/component/login/login.component.ts
+++ b/src/app/login/component/login/login.component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
-import {Credentials} from '@xtream/firebase-ngrx-user-management';
+import {Credentials} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 import {Router} from '@angular/router';
 
 @Component({

--- a/src/app/login/container/login-container/login-container.component.ts
+++ b/src/app/login/container/login-container/login-container.component.ts
@@ -1,8 +1,8 @@
 import {Component, OnInit} from '@angular/core';
-import {AuthActions, AuthState} from '@xtream/firebase-ngrx-user-management';
+import {AuthActions, AuthState} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 import {select, Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
-import {getAuthError, isAuthSuccess} from '@xtream/firebase-ngrx-user-management';
+import {getAuthError, isAuthSuccess} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 
 @Component({
   selector: 'app-login-container',

--- a/src/app/registration/components/registration/registration.component.ts
+++ b/src/app/registration/components/registration/registration.component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
-import {Credentials} from '@xtream/firebase-ngrx-user-management';
+import {Credentials} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 
 @Component({
   selector: 'app-registration',

--- a/src/app/registration/containers/registration-container/registration-container.component.ts
+++ b/src/app/registration/containers/registration-container/registration-container.component.ts
@@ -1,9 +1,9 @@
 import {Component, OnInit} from '@angular/core';
-import {AuthActions, AuthState} from '@xtream/firebase-ngrx-user-management';
+import {AuthActions, AuthState} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 import {select, Store} from '@ngrx/store';
-import {Credentials} from '@xtream/firebase-ngrx-user-management';
+import {Credentials} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 import {Observable} from 'rxjs';
-import {getAuthError, isAuthSuccess} from '@xtream/firebase-ngrx-user-management';
+import {getAuthError, isAuthSuccess} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 
 @Component({
   selector: 'app-registration-container',

--- a/src/app/toolbar/containers/toolbar-container/toolbar-container.component.ts
+++ b/src/app/toolbar/containers/toolbar-container/toolbar-container.component.ts
@@ -2,8 +2,8 @@ import {Component, OnInit} from '@angular/core';
 import {select, Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {getUserState, UserState} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
-import {State} from '../../../core/reducers/index';
-import {AuthActions} from '@xtream/firebase-ngrx-user-management';
+import {State} from '../../../core/reducers';
+import {AuthActions} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 import {Router} from '@angular/router';
 
 @Component({

--- a/src/app/user/containers/user-container/user-container.component.ts
+++ b/src/app/user/containers/user-container/user-container.component.ts
@@ -1,10 +1,9 @@
 import {Component, OnInit} from '@angular/core';
 import {Observable} from 'rxjs';
-import {getUserState, UserState} from '@xtream/firebase-ngrx-user-management';
+import {getUserState, UserState} from '../../../../..//projects/xtream/firebase-ngrx-user-management/src/public_api';
 import {select, Store} from '@ngrx/store';
 import {State} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/lib/reducers/user.reducer';
-import {AuthActions} from '@xtream/firebase-ngrx-user-management';
-import {Actions} from '@ngrx/effects';
+import {AuthActions} from '../../../../../projects/xtream/firebase-ngrx-user-management/src/public_api';
 import {Router} from '@angular/router';
 import {environment} from '../../../../environments/environment';
 


### PR DESCRIPTION
some references in the demo app was pointing to the @xtream/firebase-ngrx-user-management module. For easier local development they now all point to the local lib.